### PR TITLE
Calling the right cxx_pretty_printer destructor

### DIFF
--- a/static_print.patch
+++ b/static_print.patch
@@ -170,7 +170,7 @@ diff -ur gcc-7.1.0/gcc/cp/constexpr.c gcc-7.1.0s/gcc/cp/constexpr.c
 +        }
 +        
 +      pp_newline_and_flush (pp);          
-+      pp->~pretty_printer ();
++      pp->~cxx_pretty_printer ();
 +      XDELETE (pp);
 +      
 +      break;
@@ -948,7 +948,7 @@ diff -ur gcc-7.1.0/gcc/cp/semantics.c gcc-7.1.0s/gcc/cp/semantics.c
 +    }
 +    
 +  pp_newline_and_flush (pp);          
-+  pp->~pretty_printer ();
++  pp->~cxx_pretty_printer ();
 +  XDELETE (pp);
 +}
 +


### PR DESCRIPTION
pp is of
`cxx_pretty_printer *` type, but the wrong destructor is called

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saarraz/static-print/1)
<!-- Reviewable:end -->
